### PR TITLE
Fix jinja2 enumerate usage

### DIFF
--- a/review_fields.py
+++ b/review_fields.py
@@ -95,7 +95,8 @@ TEMPLATE = """<!doctype html>
             <th>Example {{ i + 1 }}</th>
           {% endfor %}
         </tr>
-        {% for idx, col in enumerate(cols) %}
+        {% for col in cols %}
+        {% set idx = loop.index0 %}
         <tr>
           <td><input type='checkbox' name='{{ rrf }}::{{ col }}' {% if selections.get(rrf, {}).get(col) %}checked{% endif %}></td>
           <td>{{ col }}</td>


### PR DESCRIPTION
## Summary
- remove `enumerate` from Jinja2 template
- use `loop.index0` to track column index

## Testing
- `python -m py_compile review_fields.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877c444bfc0832797cd915156fdd4cd