### PR TITLE
Add MetaMapLite NLP interface

### DIFF
--- a/NLP/__init__.py
+++ b/NLP/__init__.py
@@ -1,0 +1,4 @@
+from .metamaplite import run_metamaplite
+from .api import create_app
+
+__all__ = ["run_metamaplite", "create_app"]

--- a/NLP/api.py
+++ b/NLP/api.py
@@ -1,0 +1,32 @@
+from flask import Flask, jsonify, request
+from .metamaplite import run_metamaplite
+
+
+def create_app(metamaplite_dir: str | None = None) -> Flask:
+    app = Flask(__name__)
+
+    @app.route("/annotate", methods=["POST"])
+    def annotate():
+        data = request.get_json() or {}
+        text = data.get("text", "")
+        result = run_metamaplite(text, metamaplite_dir=metamaplite_dir)
+        return jsonify(result)
+
+    return app
+
+
+def main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="MetaMapLite NLP API")
+    parser.add_argument("--host", default="0.0.0.0")
+    parser.add_argument("--port", type=int, default=5000)
+    parser.add_argument("--metamap-dir")
+    args = parser.parse_args()
+
+    app = create_app(args.metamap_dir)
+    app.run(host=args.host, port=args.port)
+
+
+if __name__ == "__main__":
+    main()

--- a/NLP/cli.py
+++ b/NLP/cli.py
@@ -1,0 +1,17 @@
+import argparse
+import json
+from .metamaplite import run_metamaplite
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Annotate text with MetaMapLite")
+    parser.add_argument("text", help="Text to annotate")
+    parser.add_argument("--metamap-dir")
+    args = parser.parse_args()
+
+    result = run_metamaplite(args.text, metamaplite_dir=args.metamap_dir)
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/NLP/metamaplite.py
+++ b/NLP/metamaplite.py
@@ -1,0 +1,13 @@
+import json
+import os
+import subprocess
+from pathlib import Path
+
+
+def run_metamaplite(text: str, metamaplite_dir: str | None = None) -> dict:
+    """Run MetaMapLite on the given text and return JSON output."""
+    metamaplite_dir = metamaplite_dir or os.environ.get("METAMAPLITE_DIR", ".")
+    jar = Path(metamaplite_dir) / "metamaplite-1.0.jar"
+    cmd = ["java", "-jar", str(jar), "--inputtext", text, "--outputformat", "json"]
+    result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+    return json.loads(result.stdout)

--- a/tests/test_nlp.py
+++ b/tests/test_nlp.py
@@ -1,0 +1,33 @@
+import sys, os
+os_sys_path = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if os_sys_path not in sys.path:
+    sys.path.insert(0, os_sys_path)
+import json
+from unittest.mock import patch
+
+from NLP.metamaplite import run_metamaplite
+from NLP.api import create_app
+
+
+def test_run_metamaplite_calls_java(tmp_path):
+    jar = tmp_path / "metamaplite-1.0.jar"
+    jar.write_text("")
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value.stdout = '{"result":"ok"}'
+        mock_run.return_value.returncode = 0
+        result = run_metamaplite("sample", metamaplite_dir=str(tmp_path))
+        mock_run.assert_called_once()
+        cmd = mock_run.call_args[0][0]
+        assert "java" in cmd[0]
+        assert str(jar) in cmd
+        assert result == {"result": "ok"}
+
+
+def test_api_annotation_returns_json():
+    app = create_app()
+    with app.test_client() as client, patch("NLP.api.run_metamaplite") as mock_run:
+        mock_run.return_value = {"utterances": []}
+        resp = client.post("/annotate", json={"text": "hi"})
+        assert resp.status_code == 200
+        assert resp.get_json() == {"utterances": []}
+        mock_run.assert_called_once_with("hi", metamaplite_dir=None)


### PR DESCRIPTION
## Summary
- add MetaMapLite wrapper, API and CLI in `NLP` folder
- provide minimal Flask REST API
- add tests for command creation and Flask endpoint
- remove compiled files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a87bb7dd48327ab53b0ad49b01a16