### PR TITLE
Filter out invalid MRCOLS rows

### DIFF
--- a/Data/MRCOLS.RRF
+++ b/Data/MRCOLS.RRF
@@ -15,9 +15,6 @@ AV|Average Length, Characters||4|4.12|6|MRCOLS.RRF|numeric(5,2)|
 BTS|Size in Bytes||1|7.26|10|MRFILES.RRF|integer|
 CENC|Character encoding of a source as specified by IANA||5|5.00|5|MRSAB.RRF|varchar(20)|
 CFR|CUI frequency for a source||1|4.24|6|MRSAB.RRF|integer|
-CHANGEKEY|CONCEPTSTATUS (if history relates to a SNOMED CT concept) or DESCRIPTIONSTATUS (if history relates to a SNOMED CT atom or "description")||0|0.00|0|MRHIST.RRF|varchar(1000)|
-CHANGETYPE|Source asserted code for type of change||0|0.00|0|MRHIST.RRF|varchar(1000)|
-CHANGEVAL|SNOMED CT CONCEPTSTATUS or DESCRIPTIONSTATUS value after the change took place||0|0.00|0|MRHIST.RRF|varchar(1000)|
 CLS|Number of columns||1|1.11|2|MRFILES.RRF|integer|
 CODE|Unique Identifier or code for string in source||0|4.20|56|MRSAT.RRF|varchar(100)|
 CODE|Unique Identifier or code for string in source||1|7.56|95|MRCONSO.RRF|varchar(100)|
@@ -28,10 +25,6 @@ CUI1|Unique identifier for first concept||8|8.00|8|MRREL.RRF|char(8)|
 CUI2|Unique identifier for second concept||0|3.78|8|MRCUI.RRF|char(8)|
 CUI2|Unique identifier for second concept||8|8.00|8|MRAUI.RRF|char(8)|
 CUI2|Unique identifier for second concept||8|8.00|8|MRREL.RRF|char(8)|
-CUI|Unique identifier for concept||0|0.00|0|MRHIST.RRF|char(8)|
-CUI|Unique identifier for concept||8|8.00|8|AMBIGLUI.RRF|char(8)|
-CUI|Unique identifier for concept||8|8.00|8|AMBIGSUI.RRF|char(8)|
-CUI|Unique identifier for concept||8|8.00|8|CHANGE/MERGEDCUI.RRF|char(8)|
 CUI|Unique identifier for concept||8|8.00|8|MRCONSO.RRF|char(8)|
 CUI|Unique identifier for concept||8|8.00|8|MRDEF.RRF|char(8)|
 CUI|Unique identifier for concept||8|8.00|8|MRHIER.RRF|char(8)|
@@ -39,43 +32,11 @@ CUI|Unique identifier for concept||8|8.00|8|MRSAT.RRF|char(8)|
 CUI|Unique identifier for concept||8|8.00|8|MRSTY.RRF|char(8)|
 CUI|Unique identifier for concept||8|8.00|8|MRXNS_ENG.RRF|char(8)|
 CUI|Unique identifier for concept||8|8.00|8|MRXNW_ENG.RRF|char(8)|
-CUI|Unique identifier for concept||8|8.00|8|MRXW_ARA.RRF|char(8)|
-CUI|Unique identifier for concept||8|8.00|8|MRXW_BAQ.RRF|char(8)|
-CUI|Unique identifier for concept||8|8.00|8|MRXW_CHI.RRF|char(8)|
-CUI|Unique identifier for concept||8|8.00|8|MRXW_CZE.RRF|char(8)|
-CUI|Unique identifier for concept||8|8.00|8|MRXW_DAN.RRF|char(8)|
-CUI|Unique identifier for concept||8|8.00|8|MRXW_DUT.RRF|char(8)|
-CUI|Unique identifier for concept||8|8.00|8|MRXW_ENG.RRF|char(8)|
-CUI|Unique identifier for concept||8|8.00|8|MRXW_EST.RRF|char(8)|
-CUI|Unique identifier for concept||8|8.00|8|MRXW_FIN.RRF|char(8)|
-CUI|Unique identifier for concept||8|8.00|8|MRXW_FRE.RRF|char(8)|
-CUI|Unique identifier for concept||8|8.00|8|MRXW_GER.RRF|char(8)|
-CUI|Unique identifier for concept||8|8.00|8|MRXW_GRE.RRF|char(8)|
-CUI|Unique identifier for concept||8|8.00|8|MRXW_HEB.RRF|char(8)|
-CUI|Unique identifier for concept||8|8.00|8|MRXW_HUN.RRF|char(8)|
-CUI|Unique identifier for concept||8|8.00|8|MRXW_ISL.RRF|char(8)|
-CUI|Unique identifier for concept||8|8.00|8|MRXW_ITA.RRF|char(8)|
-CUI|Unique identifier for concept||8|8.00|8|MRXW_JPN.RRF|char(8)|
-CUI|Unique identifier for concept||8|8.00|8|MRXW_KOR.RRF|char(8)|
-CUI|Unique identifier for concept||8|8.00|8|MRXW_LAV.RRF|char(8)|
-CUI|Unique identifier for concept||8|8.00|8|MRXW_LIT.RRF|char(8)|
-CUI|Unique identifier for concept||8|8.00|8|MRXW_NOR.RRF|char(8)|
-CUI|Unique identifier for concept||8|8.00|8|MRXW_POL.RRF|char(8)|
-CUI|Unique identifier for concept||8|8.00|8|MRXW_POR.RRF|char(8)|
-CUI|Unique identifier for concept||8|8.00|8|MRXW_RUS.RRF|char(8)|
-CUI|Unique identifier for concept||8|8.00|8|MRXW_SCR.RRF|char(8)|
-CUI|Unique identifier for concept||8|8.00|8|MRXW_SPA.RRF|char(8)|
-CUI|Unique identifier for concept||8|8.00|8|MRXW_SWE.RRF|char(8)|
-CUI|Unique identifier for concept||8|8.00|8|MRXW_TUR.RRF|char(8)|
-CUI|Unique identifier for concept||8|8.00|8|MRXW_UKR.RRF|char(8)|
 CURVER|Current Version flag||1|1.00|1|MRSAB.RRF|char(1)|
 CVF|Content view flag||0|0.00|0|MRDEF.RRF|varchar(50)|
 CVF|Content view flag||0|0.00|0|MRHIER.RRF|varchar(50)|
-CVF|Content view flag||0|0.00|0|MRHIST.RRF|varchar(50)|
-CVF|Content view flag||0|0.00|0|MRMAP.RRF|varchar(50)|
 CVF|Content view flag||0|0.00|0|MRREL.RRF|varchar(50)|
 CVF|Content view flag||0|0.00|0|MRSAT.RRF|varchar(50)|
-CVF|Content view flag||0|0.00|0|MRSMAP.RRF|varchar(50)|
 CVF|Content view flag||0|0.94|5|MRCONSO.RRF|varchar(50)|
 CVF|Content view flag||0|1.81|5|MRSTY.RRF|varchar(50)|
 CXN|The context number if the atom has multiple contexts||1|2.26|5|MRHIER.RRF|integer|
@@ -90,133 +51,36 @@ EXPL|Detailed explanation||0|26.29|941|MRDOC.RRF|varchar(1000)|
 FIL|Physical FILENAME||9|11.02|21|MRCOLS.RRF|varchar(50)|
 FIL|Physical FILENAME||9|12.11|21|MRFILES.RRF|varchar(50)|
 FMT|Comma separated list of COL||7|29.26|190|MRFILES.RRF|varchar(300)|
-FROMEXPR|The expression that a mapping is mapped from||1|6.91|8|MRSMAP.RRF|varchar(4000)|
-FROMEXPR|The expression that a mapping is mapped from||1|8.46|18|MRMAP.RRF|varchar(4000)|
-FROMID|Metathesaurus identifier for the entity being mapped from||1|7.54|18|MRMAP.RRF|varchar(50)|
-FROMRES|Restriction applicable to the entity being mapped from||0|0.00|0|MRMAP.RRF|varchar(4000)|
-FROMRULE|Machine processible rule applicable to the entity being mapped from||0|0.00|0|MRMAP.RRF|varchar(4000)|
-FROMSID|Source asserted identifier for the entity being mapped from||0|0.00|0|MRMAP.RRF|varchar(50)|
-FROMTYPE|The type of expression that a mapping is mapped from||3|3.98|4|MRSMAP.RRF|varchar(50)|
-FROMTYPE|The type of expression that a mapping is mapped from||3|3.99|4|MRMAP.RRF|varchar(50)|
 HCD|Source asserted hierarchical number or code of context member (if it exists)||0|0.41|51|MRHIER.RRF|varchar(100)|
 IMETA|Version of the Metathesaurus that a source was added||6|6.00|6|MRSAB.RRF|varchar(10)|
 ISPREF|Indicates whether AUI is preferred||1|1.00|1|MRCONSO.RRF|char(1)|
-LAT|Language of Term(s)||0|0.00|0|CHANGE/DELETEDSUI.RRF|char(3)|
 LAT|Language of Term(s)||0|2.97|3|MRSAB.RRF|char(3)|
 LAT|Language of Term(s)||3|3.00|3|MRCONSO.RRF|char(3)|
 LAT|Language of Term(s)||3|3.00|3|MRXNS_ENG.RRF|char(3)|
 LAT|Language of Term(s)||3|3.00|3|MRXNW_ENG.RRF|char(3)|
-LAT|Language of Term(s)||3|3.00|3|MRXW_ARA.RRF|char(3)|
-LAT|Language of Term(s)||3|3.00|3|MRXW_BAQ.RRF|char(3)|
-LAT|Language of Term(s)||3|3.00|3|MRXW_CHI.RRF|char(3)|
-LAT|Language of Term(s)||3|3.00|3|MRXW_CZE.RRF|char(3)|
-LAT|Language of Term(s)||3|3.00|3|MRXW_DAN.RRF|char(3)|
-LAT|Language of Term(s)||3|3.00|3|MRXW_DUT.RRF|char(3)|
-LAT|Language of Term(s)||3|3.00|3|MRXW_ENG.RRF|char(3)|
-LAT|Language of Term(s)||3|3.00|3|MRXW_EST.RRF|char(3)|
-LAT|Language of Term(s)||3|3.00|3|MRXW_FIN.RRF|char(3)|
-LAT|Language of Term(s)||3|3.00|3|MRXW_FRE.RRF|char(3)|
-LAT|Language of Term(s)||3|3.00|3|MRXW_GER.RRF|char(3)|
-LAT|Language of Term(s)||3|3.00|3|MRXW_GRE.RRF|char(3)|
-LAT|Language of Term(s)||3|3.00|3|MRXW_HEB.RRF|char(3)|
-LAT|Language of Term(s)||3|3.00|3|MRXW_HUN.RRF|char(3)|
-LAT|Language of Term(s)||3|3.00|3|MRXW_ISL.RRF|char(3)|
-LAT|Language of Term(s)||3|3.00|3|MRXW_ITA.RRF|char(3)|
-LAT|Language of Term(s)||3|3.00|3|MRXW_JPN.RRF|char(3)|
-LAT|Language of Term(s)||3|3.00|3|MRXW_KOR.RRF|char(3)|
-LAT|Language of Term(s)||3|3.00|3|MRXW_LAV.RRF|char(3)|
-LAT|Language of Term(s)||3|3.00|3|MRXW_LIT.RRF|char(3)|
-LAT|Language of Term(s)||3|3.00|3|MRXW_NOR.RRF|char(3)|
-LAT|Language of Term(s)||3|3.00|3|MRXW_POL.RRF|char(3)|
-LAT|Language of Term(s)||3|3.00|3|MRXW_POR.RRF|char(3)|
-LAT|Language of Term(s)||3|3.00|3|MRXW_RUS.RRF|char(3)|
-LAT|Language of Term(s)||3|3.00|3|MRXW_SCR.RRF|char(3)|
-LAT|Language of Term(s)||3|3.00|3|MRXW_SPA.RRF|char(3)|
-LAT|Language of Term(s)||3|3.00|3|MRXW_SWE.RRF|char(3)|
-LAT|Language of Term(s)||3|3.00|3|MRXW_TUR.RRF|char(3)|
-LAT|Language of Term(s)||3|3.00|3|MRXW_UKR.RRF|char(3)|
-LUI|Unique identifier for term||0|0.00|0|CHANGE/MERGEDLUI.RRF|varchar(10)|
 LUI|Unique identifier for term||0|4.20|9|MRSAT.RRF|varchar(10)|
-LUI|Unique identifier for term||8|8.00|8|MRXW_BAQ.RRF|varchar(10)|
-LUI|Unique identifier for term||8|8.00|8|MRXW_DAN.RRF|varchar(10)|
-LUI|Unique identifier for term||8|8.00|8|MRXW_HEB.RRF|varchar(10)|
-LUI|Unique identifier for term||8|8.21|9|MRXW_JPN.RRF|varchar(10)|
-LUI|Unique identifier for term||8|8.27|9|AMBIGLUI.RRF|varchar(10)|
-LUI|Unique identifier for term||8|8.45|9|MRXW_CZE.RRF|varchar(10)|
 LUI|Unique identifier for term||8|8.46|9|MRCONSO.RRF|varchar(10)|
 LUI|Unique identifier for term||8|8.46|9|MRXNS_ENG.RRF|varchar(10)|
-LUI|Unique identifier for term||8|8.46|9|MRXW_ENG.RRF|varchar(10)|
 LUI|Unique identifier for term||8|8.47|9|MRXNW_ENG.RRF|varchar(10)|
-LUI|Unique identifier for term||8|8.57|9|MRXW_GER.RRF|varchar(10)|
-LUI|Unique identifier for term||8|8.57|9|MRXW_SPA.RRF|varchar(10)|
-LUI|Unique identifier for term||8|8.67|9|MRXW_DUT.RRF|varchar(10)|
-LUI|Unique identifier for term||8|8.76|9|MRXW_ITA.RRF|varchar(10)|
-LUI|Unique identifier for term||8|8.76|9|MRXW_POR.RRF|varchar(10)|
-LUI|Unique identifier for term||8|8.79|9|MRXW_FRE.RRF|varchar(10)|
-LUI|Unique identifier for term||8|8.79|9|MRXW_RUS.RRF|varchar(10)|
-LUI|Unique identifier for term||8|8.84|9|MRXW_FIN.RRF|varchar(10)|
-LUI|Unique identifier for term||8|8.85|9|MRXW_POL.RRF|varchar(10)|
-LUI|Unique identifier for term||8|8.86|9|MRXW_SWE.RRF|varchar(10)|
-LUI|Unique identifier for term||8|8.91|9|MRXW_KOR.RRF|varchar(10)|
-LUI|Unique identifier for term||8|8.94|9|MRXW_SCR.RRF|varchar(10)|
-LUI|Unique identifier for term||8|8.98|9|MRXW_NOR.RRF|varchar(10)|
-LUI|Unique identifier for term||8|8.99|9|MRXW_HUN.RRF|varchar(10)|
-LUI|Unique identifier for term||8|8.99|9|MRXW_LAV.RRF|varchar(10)|
-LUI|Unique identifier for term||9|9.00|9|MRXW_ARA.RRF|varchar(10)|
-LUI|Unique identifier for term||9|9.00|9|MRXW_CHI.RRF|varchar(10)|
-LUI|Unique identifier for term||9|9.00|9|MRXW_EST.RRF|varchar(10)|
-LUI|Unique identifier for term||9|9.00|9|MRXW_GRE.RRF|varchar(10)|
-LUI|Unique identifier for term||9|9.00|9|MRXW_ISL.RRF|varchar(10)|
-LUI|Unique identifier for term||9|9.00|9|MRXW_LIT.RRF|varchar(10)|
-LUI|Unique identifier for term||9|9.00|9|MRXW_TUR.RRF|varchar(10)|
-LUI|Unique identifier for term||9|9.00|9|MRXW_UKR.RRF|varchar(10)|
-MAPATN|Mapping attribute name (for future use)||0|2.94|6|MRMAP.RRF|varchar(20)|
-MAPATV|Mapping attribute value (for future use)||0|0.00|1|MRMAP.RRF|varchar(4000)|
-MAPID|Metathesaurus asserted identifier for mapping||10|10.98|11|MRSMAP.RRF|varchar(50)|
-MAPID|Metathesaurus asserted identifier for mapping||10|10.99|11|MRMAP.RRF|varchar(50)|
 MAPIN|Mapping in current subset||0|0.47|1|MRCUI.RRF|char(1)|
 MAPIN|Mapping in current subset||1|1.00|1|MRAUI.RRF|char(1)|
-MAPRANK|Order in which mappings in a subset should be applied||0|0.51|2|MRMAP.RRF|integer|
 MAPREASON|Reason for mapping||0|0.00|4|MRCUI.RRF|varchar(4000)|
 MAPREASON|Reason for mapping||4|4.00|4|MRAUI.RRF|varchar(4000)|
-MAPRES|Restriction applicable to this mapping||0|38.67|429|MRMAP.RRF|varchar(4000)|
-MAPRULE|Machine processible rule applicable to this mapping||0|11.54|336|MRMAP.RRF|varchar(4000)|
-MAPSETCUI|CUI of the map set||8|8.00|8|MRMAP.RRF|char(8)|
-MAPSETCUI|CUI of the map set||8|8.00|8|MRSMAP.RRF|char(8)|
-MAPSETSAB|SAB of the map set||3|10.49|13|MRSMAP.RRF|varchar(40)|
-MAPSETSAB|SAB of the map set||3|10.67|13|MRMAP.RRF|varchar(40)|
-MAPSID|Source asserted identifier for mapping||0|0.00|0|MRSMAP.RRF|varchar(50)|
-MAPSID|Source asserted identifier for mapping||0|0.00|36|MRMAP.RRF|varchar(50)|
-MAPSUBSETID|Map subset identifier used to identify a subset of related mappings within a map set||0|0.51|1|MRMAP.RRF|varchar(10)|
-MAPTYPE|Type of mapping||0|4.44|9|MRMAP.RRF|varchar(50)|
 MAX|Maximum Length||1|1.36|5|MRCOLS.RRF|integer|
 METAUI|Metathesaurus asserted unique identifier||0|8.28|10|MRSAT.RRF|varchar(50)|
 MIN|Minimum Length||1|1.03|2|MRCOLS.RRF|integer|
 NSTR|Normalized string||1|39.23|2528|MRXNS_ENG.RRF|varchar(3000)|
 NWD|Normalized word||1|6.46|80|MRXNW_ENG.RRF|varchar(100)|
 PAUI|Unique identifier for parent atom||0|8.55|9|MRHIER.RRF|varchar(9)|
-PCUI|Concept unique identifier in the previous Metathesaurus||8|8.00|8|CHANGE/DELETEDCUI.RRF|char(8)|
-PCUI|Concept unique identifier in the previous Metathesaurus||8|8.00|8|CHANGE/MERGEDCUI.RRF|char(8)|
-PLUI|Lexical unique identifier in the previous Metathesaurus||0|0.00|0|CHANGE/DELETEDLUI.RRF|varchar(10)|
-PLUI|Lexical unique identifier in the previous Metathesaurus||0|0.00|0|CHANGE/MERGEDLUI.RRF|varchar(10)|
-PSTR|Preferred name in the previous Metathesaurus||0|0.00|0|CHANGE/DELETEDLUI.RRF|varchar(3000)|
-PSTR|Preferred name in the previous Metathesaurus||0|0.00|0|CHANGE/DELETEDSUI.RRF|varchar(3000)|
-PSTR|Preferred name in the previous Metathesaurus||4|4.00|4|CHANGE/DELETEDCUI.RRF|varchar(3000)|
-PSUI|String unique identifier in the previous Metathesaurus||0|0.00|0|CHANGE/DELETEDSUI.RRF|varchar(10)|
 PTR|Path to root||0|105.07|353|MRHIER.RRF|varchar(1000)|
 RANK|Termgroup ranking||4|4.00|4|MRRANK.RRF|integer|
 RCUI|Unique identifier for root SRC concept||8|8.00|8|MRSAB.RRF|char(8)|
-REASON|Explanation of change, if present||0|0.00|0|MRHIST.RRF|varchar(1000)|
 REF|Documentation Section Number||0|0.00|0|MRCOLS.RRF|varchar(20)|
 RELA|Additional relationship label||0|0.00|0|MRAUI.RRF|varchar(100)|
 RELA|Additional relationship label||0|0.00|0|MRCUI.RRF|varchar(100)|
 RELA|Additional relationship label||0|11.42|54|MRREL.RRF|varchar(100)|
-RELA|Additional relationship label||0|13.70|37|MRMAP.RRF|varchar(100)|
-RELA|Additional relationship label||0|19.61|37|MRSMAP.RRF|varchar(100)|
 RELA|Additional relationship label||0|2.72|12|MRHIER.RRF|varchar(100)|
 REL|Relationship label||0|0.00|0|MRAUI.RRF|varchar(4)|
-REL|Relationship label||2|2.00|2|MRMAP.RRF|varchar(4)|
-REL|Relationship label||2|2.00|2|MRSMAP.RRF|varchar(4)|
 REL|Relationship label||2|2.22|3|MRREL.RRF|varchar(4)|
 REL|Relationship label||2|2.53|3|MRCUI.RRF|varchar(4)|
 RG|Relationship group||0|0.11|3|MRREL.RRF|varchar(10)|
@@ -225,7 +89,6 @@ RSAB|Root source abbreviation||2|5.91|15|MRSAB.RRF|varchar(40)|
 RUI|Unique identifier for relationship||9|9.80|10|MRREL.RRF|varchar(10)|
 RWS|Number of rows||1|5.59|8|MRFILES.RRF|integer|
 SABIN|Source in current subset||1|1.00|1|MRSAB.RRF|char(1)|
-SAB|Source abbreviation||0|0.00|0|MRHIST.RRF|varchar(40)|
 SAB|Source abbreviation||2|4.15|11|MRDEF.RRF|varchar(40)|
 SAB|Source abbreviation||2|5.52|15|MRRANK.RRF|varchar(40)|
 SAB|Source abbreviation||2|5.92|15|MRCONSO.RRF|varchar(40)|
@@ -243,7 +106,6 @@ SF|Source Family||2|4.15|13|MRSAB.RRF|varchar(40)|
 SLC|License contact info for a source||12|167.50|346|MRSAB.RRF|varchar(1000)|
 SL|Source of relationship labels||2|5.97|15|MRREL.RRF|varchar(40)|
 SON|Source Official Name||10|49.61|145|MRSAB.RRF|varchar(3000)|
-SOURCEUI|Source asserted unique identifier||0|0.00|0|MRHIST.RRF|varchar(50)|
 SRL|Source Restriction Level||1|1.00|1|MRCONSO.RRF|integer|
 SRL|Source Restriction Level||1|1.00|1|MRSAB.RRF|integer|
 SRUI|Source attributed relationship identifier||0|2.50|36|MRREL.RRF|varchar(50)|
@@ -256,55 +118,16 @@ STYPE2|The name of the column in MRCONSO.RRF that contains the second identifier
 STYPE|The name of the column in MRCONSO.RRF or MRREL.RRF that contains the identifier to which the attribute is attached||3|3.21|4|MRSAT.RRF|varchar(50)|
 STY|Semantic type||4|17.42|39|MRSTY.RRF|varchar(50)|
 SUI|Unique identifier for string||0|4.26|9|MRSAT.RRF|varchar(10)|
-SUI|Unique identifier for string||8|8.00|8|MRXW_BAQ.RRF|varchar(10)|
-SUI|Unique identifier for string||8|8.00|8|MRXW_DAN.RRF|varchar(10)|
-SUI|Unique identifier for string||8|8.00|8|MRXW_HEB.RRF|varchar(10)|
-SUI|Unique identifier for string||8|8.36|9|MRXW_JPN.RRF|varchar(10)|
-SUI|Unique identifier for string||8|8.37|9|AMBIGSUI.RRF|varchar(10)|
 SUI|Unique identifier for string||8|8.59|9|MRCONSO.RRF|varchar(10)|
-SUI|Unique identifier for string||8|8.60|9|MRXW_GER.RRF|varchar(10)|
-SUI|Unique identifier for string||8|8.61|9|MRXW_SPA.RRF|varchar(10)|
 SUI|Unique identifier for string||8|8.65|9|MRXNS_ENG.RRF|varchar(10)|
-SUI|Unique identifier for string||8|8.67|9|MRXW_ENG.RRF|varchar(10)|
 SUI|Unique identifier for string||8|8.68|9|MRXNW_ENG.RRF|varchar(10)|
-SUI|Unique identifier for string||8|8.68|9|MRXW_DUT.RRF|varchar(10)|
-SUI|Unique identifier for string||8|8.78|9|MRXW_POR.RRF|varchar(10)|
-SUI|Unique identifier for string||8|8.79|9|MRXW_ITA.RRF|varchar(10)|
-SUI|Unique identifier for string||8|8.80|9|MRXW_RUS.RRF|varchar(10)|
-SUI|Unique identifier for string||8|8.84|9|MRXW_FIN.RRF|varchar(10)|
-SUI|Unique identifier for string||8|8.84|9|MRXW_FRE.RRF|varchar(10)|
-SUI|Unique identifier for string||8|8.87|9|MRXW_SWE.RRF|varchar(10)|
-SUI|Unique identifier for string||8|8.88|9|MRXW_CZE.RRF|varchar(10)|
-SUI|Unique identifier for string||8|8.98|9|MRXW_NOR.RRF|varchar(10)|
-SUI|Unique identifier for string||8|8.99|9|MRXW_HUN.RRF|varchar(10)|
-SUI|Unique identifier for string||9|9.00|9|MRXW_ARA.RRF|varchar(10)|
-SUI|Unique identifier for string||9|9.00|9|MRXW_CHI.RRF|varchar(10)|
-SUI|Unique identifier for string||9|9.00|9|MRXW_EST.RRF|varchar(10)|
-SUI|Unique identifier for string||9|9.00|9|MRXW_GRE.RRF|varchar(10)|
-SUI|Unique identifier for string||9|9.00|9|MRXW_ISL.RRF|varchar(10)|
-SUI|Unique identifier for string||9|9.00|9|MRXW_KOR.RRF|varchar(10)|
-SUI|Unique identifier for string||9|9.00|9|MRXW_LAV.RRF|varchar(10)|
-SUI|Unique identifier for string||9|9.00|9|MRXW_LIT.RRF|varchar(10)|
-SUI|Unique identifier for string||9|9.00|9|MRXW_POL.RRF|varchar(10)|
-SUI|Unique identifier for string||9|9.00|9|MRXW_SCR.RRF|varchar(10)|
-SUI|Unique identifier for string||9|9.00|9|MRXW_TUR.RRF|varchar(10)|
-SUI|Unique identifier for string||9|9.00|9|MRXW_UKR.RRF|varchar(10)|
 SUPPRESS|Suppressible flag||1|1.00|1|MRCONSO.RRF|char(1)|
 SUPPRESS|Suppressible flag||1|1.00|1|MRDEF.RRF|char(1)|
 SUPPRESS|Suppressible flag||1|1.00|1|MRRANK.RRF|char(1)|
 SUPPRESS|Suppressible flag||1|1.00|1|MRREL.RRF|char(1)|
 SUPPRESS|Suppressible flag||1|1.00|1|MRSAT.RRF|char(1)|
-SVER|Release date or version number of a source||0|0.00|0|MRHIST.RRF|varchar(20)|
 SVER|Release date or version number of a source||0|5.02|15|MRSAB.RRF|varchar(20)|
 TFR|Term frequency for a source||1|4.56|7|MRSAB.RRF|integer|
-TOEXPR|The expression that a mapping is mapped to||0|6.07|242|MRMAP.RRF|varchar(4000)|
-TOEXPR|The expression that a mapping is mapped to||1|7.02|242|MRSMAP.RRF|varchar(4000)|
-TOID|Metathesaurus identifier for the entity being mapped to||0|5.27|18|MRMAP.RRF|varchar(50)|
-TORES|Restriction applicable to the entity being mapped to||0|0.00|0|MRMAP.RRF|varchar(4000)|
-TORULE|Machine processible rule applicable to the entity being mapped to||0|0.00|0|MRMAP.RRF|varchar(4000)|
-TOSID|Source asserted identifier for the entity being mapped to||0|0.00|0|MRMAP.RRF|varchar(50)|
-TOTYPE|The type of expression that a mapping is mapped to||0|3.96|23|MRMAP.RRF|varchar(50)|
-TOTYPE|The type of expression that a mapping is mapped to||4|4.35|22|MRSMAP.RRF|varchar(50)|
 TS|Term status||1|1.00|1|MRCONSO.RRF|char(1)|
 TTYL|Term type list for a source||0|15.76|129|MRSAB.RRF|varchar(400)|
 TTY|Term type in source||2|2.38|11|MRCONSO.RRF|varchar(20)|
@@ -318,32 +141,3 @@ VER|Last release version in which CUI1 was valid||6|6.00|6|MRAUI.RRF|varchar(10)
 VER|Last release version in which CUI1 was valid||6|6.00|6|MRCUI.RRF|varchar(10)|
 VSAB|Versioned source abbreviation||3|11.33|24|MRSAB.RRF|varchar(40)|
 VSTART|Valid start date for a source||0|0.00|0|MRSAB.RRF|char(8)|
-WD|Word in lower-case||1|2.84|38|MRXW_KOR.RRF|varchar(500)|
-WD|Word in lower-case||1|3.66|68|MRXW_CHI.RRF|varchar(500)|
-WD|Word in lower-case||1|5.26|37|MRXW_TUR.RRF|varchar(500)|
-WD|Word in lower-case||1|5.35|22|MRXW_ARA.RRF|varchar(500)|
-WD|Word in lower-case||1|5.72|38|MRXW_POR.RRF|varchar(500)|
-WD|Word in lower-case||1|5.91|38|MRXW_ITA.RRF|varchar(500)|
-WD|Word in lower-case||1|6.12|19|MRXW_HEB.RRF|varchar(500)|
-WD|Word in lower-case||1|6.13|38|MRXW_GRE.RRF|varchar(500)|
-WD|Word in lower-case||1|6.15|80|MRXW_ENG.RRF|varchar(500)|
-WD|Word in lower-case||1|6.36|27|MRXW_UKR.RRF|varchar(500)|
-WD|Word in lower-case||1|6.38|25|MRXW_DAN.RRF|varchar(500)|
-WD|Word in lower-case||1|6.62|46|MRXW_SPA.RRF|varchar(500)|
-WD|Word in lower-case||1|6.77|39|MRXW_FRE.RRF|varchar(500)|
-WD|Word in lower-case||1|7.01|35|MRXW_EST.RRF|varchar(500)|
-WD|Word in lower-case||1|7.15|51|MRXW_DUT.RRF|varchar(500)|
-WD|Word in lower-case||1|7.17|18|MRXW_BAQ.RRF|varchar(500)|
-WD|Word in lower-case||1|7.17|40|MRXW_RUS.RRF|varchar(500)|
-WD|Word in lower-case||1|7.25|48|MRXW_POL.RRF|varchar(500)|
-WD|Word in lower-case||1|7.33|42|MRXW_ISL.RRF|varchar(500)|
-WD|Word in lower-case||1|7.45|52|MRXW_CZE.RRF|varchar(500)|
-WD|Word in lower-case||1|7.70|37|MRXW_SCR.RRF|varchar(500)|
-WD|Word in lower-case||1|7.76|29|MRXW_LAV.RRF|varchar(500)|
-WD|Word in lower-case||1|7.82|31|MRXW_LIT.RRF|varchar(500)|
-WD|Word in lower-case||1|7.87|27|MRXW_HUN.RRF|varchar(500)|
-WD|Word in lower-case||1|8.26|43|MRXW_GER.RRF|varchar(500)|
-WD|Word in lower-case||1|8.32|39|MRXW_SWE.RRF|varchar(500)|
-WD|Word in lower-case||1|9.11|44|MRXW_NOR.RRF|varchar(500)|
-WD|Word in lower-case||1|9.13|93|MRXW_JPN.RRF|varchar(500)|
-WD|Word in lower-case||1|9.94|54|MRXW_FIN.RRF|varchar(500)|


### PR DESCRIPTION
## Summary
- remove rows from `MRCOLS.RRF` whose referenced file isn't listed in `MRFILES.RRF`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a89c85918832799198f7de9de2221