### PR TITLE
Add relationship JSON generator

### DIFF
--- a/applications/NLP/__init__.py
+++ b/applications/NLP/__init__.py
@@ -1,0 +1,4 @@
+from .metamaplite import run_metamaplite
+from .api import create_app
+
+__all__ = ["run_metamaplite", "create_app"]

--- a/applications/NLP/api.py
+++ b/applications/NLP/api.py
@@ -1,0 +1,15 @@
+from flask import Flask, jsonify, request
+from NLP.metamaplite import run_metamaplite
+
+
+def create_app(metamaplite_dir: str | None = None) -> Flask:
+    app = Flask(__name__)
+
+    @app.route("/annotate", methods=["POST"])
+    def annotate():
+        data = request.get_json() or {}
+        text = data.get("text", "")
+        result = run_metamaplite(text, metamaplite_dir=metamaplite_dir)
+        return jsonify(result)
+
+    return app

--- a/applications/NLP/metamaplite.py
+++ b/applications/NLP/metamaplite.py
@@ -1,0 +1,1 @@
+from nlp.metamaplite import *

--- a/applications/generate_relationship_json.py
+++ b/applications/generate_relationship_json.py
@@ -1,0 +1,72 @@
+import csv
+import json
+import argparse
+from pathlib import Path
+
+
+def load_preferred_names(conso_path: Path) -> dict[str, str]:
+    """Return a mapping of CUI -> preferred English name from MRCONSO."""
+    names: dict[str, tuple[str, bool]] = {}
+    with conso_path.open('r', encoding='utf-8', errors='ignore') as f:
+        reader = csv.reader(f, delimiter='|')
+        for row in reader:
+            if row and row[-1] == '':
+                row = row[:-1]
+            if len(row) < 17:
+                continue
+            cui = row[0]
+            lat = row[1]
+            ispref = row[6]
+            string = row[14]
+            suppress = row[16]
+            if lat != 'ENG' or suppress != 'N':
+                continue
+            current = names.get(cui)
+            if current is None or (ispref == 'Y' and not current[1]):
+                names[cui] = (string, ispref == 'Y')
+    return {k: v[0] for k, v in names.items()}
+
+
+def relationships_to_json(rel_path: Path, names: dict[str, str], out_path: Path) -> None:
+    """Write a JSON array with relationship info and preferred names."""
+    data = []
+    with rel_path.open('r', encoding='utf-8', errors='ignore') as f:
+        reader = csv.reader(f, delimiter='|')
+        for row in reader:
+            if row and row[-1] == '':
+                row = row[:-1]
+            if len(row) < 12:
+                continue
+            cui1 = row[0]
+            cui2 = row[4]
+            rel = row[3]
+            rela = row[7]
+            sab = row[10]
+            data.append({
+                "CUI1": cui1,
+                "CUI2": cui2,
+                "REL": rel,
+                "RELA": rela,
+                "SAB": sab,
+                "CUI1_name": names.get(cui1),
+                "CUI2_name": names.get(cui2),
+            })
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with out_path.open('w', encoding='utf-8') as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate JSON from MRREL with preferred names")
+    parser.add_argument('--data-dir', default='Data', help='Directory containing MRCONSO.RRF and MRREL.RRF')
+    parser.add_argument('--output', default='data/relationships/relationships.json', help='Output JSON file path')
+    args = parser.parse_args()
+    data_dir = Path(args.data_dir)
+    conso_path = data_dir / 'MRCONSO.RRF'
+    rel_path = data_dir / 'MRREL.RRF'
+    names = load_preferred_names(conso_path)
+    relationships_to_json(rel_path, names, Path(args.output))
+
+
+if __name__ == '__main__':
+    main()

--- a/applications/nlp/metamaplite.py
+++ b/applications/nlp/metamaplite.py
@@ -1,1 +1,14 @@
-from nlp.metamaplite import *
+import json
+import subprocess
+from pathlib import Path
+from typing import Optional, Dict
+
+
+def run_metamaplite(text: str, metamaplite_dir: Optional[str] = None) -> Dict:
+    """Run MetaMapLite on *text* and return parsed JSON output."""
+    jar_name = "metamaplite-1.0.jar"
+    jar_path = Path(metamaplite_dir or '.') / jar_name
+    cmd = ["java", "-jar", str(jar_path), text]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    result.check_returncode()
+    return json.loads(result.stdout or '{}')

--- a/applications/tests/test_relationship_json.py
+++ b/applications/tests/test_relationship_json.py
@@ -1,0 +1,52 @@
+import json
+from pathlib import Path
+
+from generate_relationship_json import load_preferred_names, relationships_to_json
+
+
+MRCONSO_SAMPLE = """\
+C0000001|ENG|P|L1|PF|S1|Y|A1|SAUI1|SCUI1|SDUI1|SAB1|TTY|CODE1|Heart Attack|SRL|N|
+C0000002|ENG|P|L2|PF|S2|N|A2|SAUI2|SCUI2|SDUI2|SAB1|TTY|CODE2|Myocardial Infarction|SRL|N|
+C0000003|ENG|P|L3|PF|S3|Y|A3|SAUI3|SCUI3|SDUI3|SAB2|TTY|CODE3|Hypertension|SRL|N|
+"""
+
+MRREL_SAMPLE = """\
+C0000001|A1|CUI|CHD|C0000003|A3|CUI|revised|RUI1||SAB1|SL||1|N|0|
+C0000001|A1|CUI|SY|C0000002|A2|CUI|synonym|RUI2||SAB1|SL||1|N|0|
+"""
+
+
+def test_relationship_json(tmp_path: Path):
+    data_dir = tmp_path
+    (data_dir / "MRCONSO.RRF").write_text(MRCONSO_SAMPLE)
+    (data_dir / "MRREL.RRF").write_text(MRREL_SAMPLE)
+
+    names = load_preferred_names(data_dir / "MRCONSO.RRF")
+    assert names["C0000001"] == "Heart Attack"
+    assert names["C0000002"] == "Myocardial Infarction"
+    assert names["C0000003"] == "Hypertension"
+
+    out_path = data_dir / "out.json"
+    relationships_to_json(data_dir / "MRREL.RRF", names, out_path)
+
+    data = json.loads(out_path.read_text())
+    assert data == [
+        {
+            "CUI1": "C0000001",
+            "CUI2": "C0000003",
+            "REL": "CHD",
+            "RELA": "revised",
+            "SAB": "SAB1",
+            "CUI1_name": "Heart Attack",
+            "CUI2_name": "Hypertension",
+        },
+        {
+            "CUI1": "C0000001",
+            "CUI2": "C0000002",
+            "REL": "SY",
+            "RELA": "synonym",
+            "SAB": "SAB1",
+            "CUI1_name": "Heart Attack",
+            "CUI2_name": "Myocardial Infarction",
+        },
+    ]

--- a/data/relationships/relationships.json
+++ b/data/relationships/relationships.json
@@ -1,0 +1,20 @@
+[
+  {
+    "CUI1": "C0000001",
+    "CUI2": "C0000003",
+    "REL": "CHD",
+    "RELA": "revised",
+    "SAB": "SAB1",
+    "CUI1_name": "Heart Attack",
+    "CUI2_name": "Hypertension"
+  },
+  {
+    "CUI1": "C0000001",
+    "CUI2": "C0000002",
+    "REL": "SY",
+    "RELA": "synonym",
+    "SAB": "SAB1",
+    "CUI1_name": "Heart Attack",
+    "CUI2_name": "Myocardial Infarction"
+  }
+]


### PR DESCRIPTION
## Summary
- implement `generate_relationship_json.py` for MRREL to JSON conversion
- create alias `applications/NLP` for compatibility with tests
- implement `run_metamaplite` helper
- include sample JSON output
- test JSON generation logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a9a5883bc8327a87536e2cb453cda