### PR TITLE
Fix line break handling in web demo

### DIFF
--- a/applications/nlp/index.html
+++ b/applications/nlp/index.html
@@ -65,6 +65,10 @@
         #output {
             margin-top: 1em;
         }
+
+        #output p {
+            white-space: pre-wrap;
+        }
     </style>
 </head>
 


### PR DESCRIPTION
## Summary
- ensure line breaks remain visible in the MetaMapLite demo

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688148f1731083279695f0038022764e