### PR TITLE
Fix MetaMapLite scoring

### DIFF
--- a/applications/nlp/cgi-bin/metamaplite.cgi
+++ b/applications/nlp/cgi-bin/metamaplite.cgi
@@ -43,6 +43,7 @@ MODELS="$BASE/metamaplite/data/models"
 cmd=("$MM_SH" \
       --indexdir="$INDEXDIR" \
       --modelsdir="$MODELS" \
+      --enable_scoring \
       --pipe \
       --outputformat=json)
 


### PR DESCRIPTION
## Summary
- enable concept scoring when running MetaMapLite CGI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688149d8d9a083278635fd927c0ef635