### PR TITLE
Add QuickUMLS option in NLP UI

### DIFF
--- a/applications/nlp/cgi-bin/quickumls.cgi
+++ b/applications/nlp/cgi-bin/quickumls.cgi
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+import os, sys, json, urllib.parse
+
+try:
+    from quickumls import QuickUMLS
+except Exception as e:
+    print("Status: 500 Internal Server Error\n")
+    print("Content-Type: text/plain\n")
+    print()
+    print("QuickUMLS not installed: %s" % e)
+    sys.exit(0)
+
+def main():
+    length = int(os.environ.get('CONTENT_LENGTH', '0'))
+    body = sys.stdin.read(length)
+    params = urllib.parse.parse_qs(body)
+    text = params.get('text', [''])[0]
+    debug = 'debug' in params
+    base = os.path.join(os.path.dirname(__file__), '..')
+    quickumls_dir = os.environ.get('QUICKUMLS_DIR', os.path.join(base, 'quickumls'))
+    matcher = QuickUMLS(quickumls_dir, best_match=True)
+    matches = matcher.match(text, best_match=True)
+    anns = []
+    for span in matches:
+        for m in span:
+            anns.append({
+                'start': m.get('start'),
+                'end': m.get('end'),
+                'ngram': m.get('ngram'),
+                'term': m.get('term'),
+                'cui': m.get('cui'),
+                'similarity': m.get('similarity'),
+                'semtypes': m.get('semtypes', [])
+            })
+    if debug:
+        print('Content-Type: text/plain')
+    else:
+        print('Content-Type: application/json')
+    print()
+    print(json.dumps(anns))
+
+if __name__ == '__main__':
+    main()

--- a/applications/nlp/index.html
+++ b/applications/nlp/index.html
@@ -78,6 +78,11 @@
             <label for="input">Clinical Text:</label>
             <textarea id="input" name="text" placeholder="Enter your sentence…"></textarea>
             <label><input type="checkbox" id="debug" name="debug"> Debug</label>
+            <label for="tool">NLP Tool:</label>
+            <select id="tool" name="tool">
+                <option value="metamaplite">MetaMapLite</option>
+                <option value="quickumls">QuickUMLS</option>
+            </select>
             <label for="filter-types">Ignore Semantic Types:</label>
             <input type="text" id="filter-types" placeholder="e.g., dsyn, patf">
 
@@ -251,9 +256,13 @@
             // collect form data
             const data = new URLSearchParams(new FormData(form));
             const debug = document.getElementById('debug').checked;
+            const tool = document.getElementById('tool').value;
+            const endpoint = tool === 'quickumls'
+                ? '/cgi-bin/quickumls.cgi'
+                : '/cgi-bin/metamaplite.cgi';
             
             try {
-                const res = await fetch('/cgi-bin/metamaplite.cgi' + (debug ? '?debug=1' : ''), {
+                const res = await fetch(endpoint + (debug ? '?debug=1' : ''), {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
                     body: data.toString()
@@ -337,6 +346,20 @@
 
         function parseAnnotations(data) {
             if (Array.isArray(data)) {
+                if (data.length && 'start' in data[0] && 'end' in data[0]) {
+                    // QuickUMLS format
+                    return data.map(ent => ({
+                        trigger: ent.ngram || ent.term || '',
+                        cui: ent.cui || '',
+                        preferredName: ent.term || '',
+                        semanticTypes: ent.semtypes || [],
+                        score: ent.similarity,
+                        span: (ent.start != null && ent.end != null)
+                            ? { begin: ent.start, end: ent.end }
+                            : null
+                    }));
+                }
+                // MetaMapLite format
                 return data.map(ent => {
                     const ev = (ent.evlist && ent.evlist[0]) || {};
                     const ci = ev.conceptinfo || {};


### PR DESCRIPTION
## Summary
- add `quickumls.cgi` for QuickUMLS lookups
- allow choosing between MetaMapLite and QuickUMLS in the NLP demo UI
- parse QuickUMLS result format

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68814bbb1d6883278867fdac21c5acc7