### PR TITLE
Add cTAKES option for NLP demo

### DIFF
--- a/applications/nlp/README.md
+++ b/applications/nlp/README.md
@@ -1,0 +1,30 @@
+# NLP Applications
+
+This directory contains small web-based demos for running clinical NLP
+engines against UMLS resources.  By default it includes support for
+[MetaMapLite](https://metamap.nlm.nih.gov/), and starting with this
+version also supports running the [Apache cTAKES](https://ctakes.apache.org/)
+engine if it is installed locally.
+
+## Running the Demo
+
+Use `serve_metamaplite.sh` to start a local HTTP server from this
+directory.  The script will automatically enable CGI support so the
+browser-based UI can call the NLP engines.
+
+```
+./serve_metamaplite.sh
+```
+
+Once running, open <http://localhost:8000> in a browser.  The page
+contains a form where you can enter clinical text.  Choose either the
+**MetaMapLite** or **cTAKES** engine from the *NLP Engine* menu, then
+click **Annotate**.
+
+## cTAKES Requirements
+
+The cTAKES option expects an existing cTAKES installation.  Set the
+`CTAKES_HOME` environment variable to point at the installation
+directory before starting the server.  The CGI script will attempt to
+run `runClinicalPipeline.sh` from this location and return its plain
+text output.

--- a/applications/nlp/cgi-bin/ctakes.cgi
+++ b/applications/nlp/cgi-bin/ctakes.cgi
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# CGI headers
+echo "Content-Type: text/plain"
+echo
+
+# Read POST body
+read -n "${CONTENT_LENGTH:-0}" body
+
+# Parse URL encoded text field
+TEXT=""
+IFS='&' read -ra pairs <<< "$body"
+for pair in "${pairs[@]}"; do
+    key=${pair%%=*}
+    val=${pair#*=}
+    val=${val//+/ }
+    val=$(printf '%b' "${val//%/\\x}")
+    case "$key" in
+        text) TEXT="$val";;
+    esac
+done
+
+CTAKES_HOME="${CTAKES_HOME:-/opt/ctakes}"
+PIPELINE="${CTAKES_PIPELINE:-$CTAKES_HOME/desc/ctakes-clinical-pipeline.xml}"
+
+if [ ! -x "$CTAKES_HOME/bin/runClinicalPipeline.sh" ]; then
+    echo "cTAKES not installed or CTAKES_HOME not set" >&2
+    echo "Error: cTAKES not installed" && exit 0
+fi
+
+TMPDIR=$(mktemp -d)
+INPUT=$TMPDIR/input.txt
+OUTPUT=$TMPDIR/output
+
+printf '%s\n' "$TEXT" > "$INPUT"
+
+"$CTAKES_HOME/bin/runClinicalPipeline.sh" -i "$INPUT" -o "$OUTPUT" -desc "$PIPELINE" -log stdout 2>&1
+
+cat "$OUTPUT"/* 2>/dev/null || true
+rm -rf "$TMPDIR"

--- a/applications/nlp/index.html
+++ b/applications/nlp/index.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="utf-8">
-    <title>MetaMapLite Demo</title>
+    <title>NLP Demo</title>
     <style>
         body {
             font-family: sans-serif;
@@ -73,13 +73,18 @@
 </head>
 
 <body>
-    <h1>MetaMapLite Demo</h1>
+    <h1>NLP Demo</h1>
         <form id="mm-form">
             <label for="input">Clinical Text:</label>
             <textarea id="input" name="text" placeholder="Enter your sentence…"></textarea>
             <label><input type="checkbox" id="debug" name="debug"> Debug</label>
             <label for="filter-types">Ignore Semantic Types:</label>
             <input type="text" id="filter-types" placeholder="e.g., dsyn, patf">
+            <label for="engine">NLP Engine:</label>
+            <select id="engine" name="engine">
+                <option value="metamaplite" selected>MetaMapLite</option>
+                <option value="ctakes">cTAKES</option>
+            </select>
 
         <!-- Simple run without restriction parameters -->
 
@@ -253,13 +258,18 @@
             const debug = document.getElementById('debug').checked;
             
             try {
-                const res = await fetch('/cgi-bin/metamaplite.cgi' + (debug ? '?debug=1' : ''), {
+                const engine = document.getElementById('engine').value;
+                const endpoint = engine === 'ctakes' ? '/cgi-bin/ctakes.cgi' : '/cgi-bin/metamaplite.cgi';
+                const res = await fetch(endpoint + (debug ? '?debug=1' : ''), {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
                     body: data.toString()
                 });
                 if (!res.ok) throw new Error(res.statusText);
-                if (debug) {
+                if (engine === 'ctakes') {
+                    const text = await res.text();
+                    output.innerHTML = '<pre>' + escapeHtml(text) + '</pre>';
+                } else if (debug) {
                     const text = await res.text();
                     output.innerHTML = '';
                     const pre = document.createElement('pre');

--- a/applications/nlp/serve_metamaplite.sh
+++ b/applications/nlp/serve_metamaplite.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 PORT="${1:-8000}"
 BASE_DIR="$(cd "$(dirname "$0")" && pwd)"
 
-echo "[*] Serving MetaMapLite UI from $BASE_DIR on http://localhost:$PORT"
+echo "[*] Serving NLP UI from $BASE_DIR on http://localhost:$PORT"
 echo "[*] Press Ctrl‑C to stop."
 
 cd "$BASE_DIR"


### PR DESCRIPTION
## Summary
- add new cTAKES CGI script and README
- update demo UI to select MetaMapLite or cTAKES
- generalize server start message

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68814bd61b8083278654145a91808518