### PR TITLE
Fix search data path

### DIFF
--- a/applications/search/README.md
+++ b/applications/search/README.md
@@ -7,9 +7,9 @@ Make sure you have the following installed and running:
 
 1. **Node.js v18+ & npm**  
 2. **Elasticsearch 8.x**
-3. **UMLS data files**  
+3. **UMLS data files**
    - Get a UMLS license: [https://uts.nlm.nih.gov/uts/signup-login](https://uts.nlm.nih.gov/uts/signup-login).
-   - Once approved, download UMLS Metathesaurus Full Subset from [https://www.nlm.nih.gov/research/umls/licensedcontent/umlsknowledgesources.html](https://www.nlm.nih.gov/research/umls/licensedcontent/umlsknowledgesources.html), which includes **MRCONSO.RRF**, **MRSTY.RRF**, and **MRRANK.RRF**
+   - Once approved, download UMLS Metathesaurus Full Subset from [https://www.nlm.nih.gov/research/umls/licensedcontent/umlsknowledgesources.html](https://www.nlm.nih.gov/research/umls/licensedcontent/umlsknowledgesources.html), which includes **MRCONSO.RRF**, **MRSTY.RRF**, **MRRANK.RRF**, and **MRDEF.RRF**
 
 ---
 
@@ -24,12 +24,14 @@ npm install                   # install @elastic/elasticsearch, etc
 
 ## 3. Copy UMLS RRF Files
 
-Place your downloaded **MRCONSO.RRF**, **MRSTY.RRF**, and **MRRANK.RRF** into the **same directory** as `load.js` (i.e. `umls-helper/umls-search/`):
+Place your downloaded **MRCONSO.RRF**, **MRSTY.RRF**, **MRRANK.RRF**, and **MRDEF.RRF** into the **same directory** as `load.js` (i.e. `umls-helper/umls-search/`):
 
 ```bash
 # from wherever you downloaded the files:
 cp /path/to/MRCONSO.RRF /path/to/umls-helper/umls-search/
 cp /path/to/MRSTY.RRF  /path/to/umls-helper/umls-search/
+cp /path/to/MRRANK.RRF /path/to/umls-helper/umls-search/
+cp /path/to/MRDEF.RRF  /path/to/umls-helper/umls-search/
 ```
 
 ---

--- a/applications/search/load.js
+++ b/applications/search/load.js
@@ -8,7 +8,8 @@ const ensureSynonymAnalyzer = require('./elastic-index'); // ✅ Import index cr
 const path = require('path');
 
 const BATCH_SIZE = 500;
-const DATA_DIR = path.join(__dirname, '..', '..', 'Data');
+// RRF files live alongside load.js
+const DATA_DIR = __dirname;
 const MRCONSO = path.join(DATA_DIR, 'MRCONSO.RRF');
 const MRSTY = path.join(DATA_DIR, 'MRSTY.RRF');
 const MRDEF = path.join(DATA_DIR, 'MRDEF.RRF');


### PR DESCRIPTION
## Summary
- fix path for MRCONSO and other RRF files in search `load.js`
- document MRDEF and include all RRF file copy commands

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68814c2c29bc83278654c90961769aa5