### PR TITLE
Fix search loader data path

### DIFF
--- a/applications/search/load.js
+++ b/applications/search/load.js
@@ -8,8 +8,8 @@ const ensureSynonymAnalyzer = require('./elastic-index'); // ✅ Import index cr
 const path = require('path');
 
 const BATCH_SIZE = 500;
-// RRF files live alongside load.js
-const DATA_DIR = __dirname;
+// RRF files live under the root Data directory
+const DATA_DIR = path.join(__dirname, '..', '..', 'Data');
 const MRCONSO = path.join(DATA_DIR, 'MRCONSO.RRF');
 const MRSTY = path.join(DATA_DIR, 'MRSTY.RRF');
 const MRDEF = path.join(DATA_DIR, 'MRDEF.RRF');


### PR DESCRIPTION
## Summary
- update path constants in the search loader script to point to repo Data folder

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_68814f7eaa0483278f4808764961f2a0