### PR TITLE
Move hierarchy script to transformation with defaults

### DIFF
--- a/applications/tests/test_generate_hierarchy.py
+++ b/applications/tests/test_generate_hierarchy.py
@@ -7,7 +7,11 @@ ROOT = Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from working.generate_hierarchy import parse_mrconso, parse_mrrel, build_tree
+from scripts.transformation.generate_hierarchy import (
+    parse_mrconso,
+    parse_mrrel,
+    build_tree,
+)
 
 
 def write_temp_file(path: Path, lines: list[str]):

--- a/scripts/transformation/generate_hierarchy.py
+++ b/scripts/transformation/generate_hierarchy.py
@@ -102,8 +102,18 @@ container.appendChild(ul);
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Generate browsable UMLS hierarchy")
-    parser.add_argument("mrrel", help="Path to MRREL.RRF")
-    parser.add_argument("mrconso", help="Path to MRCONSO.RRF")
+    parser.add_argument(
+        "mrrel",
+        nargs="?",
+        default="Data/MRREL.RRF",
+        help="Path to MRREL.RRF",
+    )
+    parser.add_argument(
+        "mrconso",
+        nargs="?",
+        default="Data/MRCONSO.RRF",
+        help="Path to MRCONSO.RRF",
+    )
     parser.add_argument("--root", help="Root CUI", required=True)
     parser.add_argument("--html", help="Output HTML file")
     args = parser.parse_args()


### PR DESCRIPTION
## Summary
- move `generate_hierarchy.py` into `scripts/transformation`
- default MRREL and MRCONSO CLI parameters to `Data` folder
- update tests to import from the new location

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68814ff3e5548327b6db0eccb255828c