### PR TITLE
Add QuickUMLS instructions to NLP README

### DIFF
--- a/applications/nlp/README.md
+++ b/applications/nlp/README.md
@@ -2,8 +2,9 @@
 
 This directory contains small web-based demos for running clinical NLP
 engines against UMLS resources.  By default it includes support for
-[MetaMapLite](https://metamap.nlm.nih.gov/), and starting with this
-version also supports running the [Apache cTAKES](https://ctakes.apache.org/)
+[MetaMapLite](https://metamap.nlm.nih.gov/) and
+[QuickUMLS](https://github.com/Georgetown-IR-Lab/QuickUMLS).  It also
+supports running the [Apache cTAKES](https://ctakes.apache.org/)
 engine if it is installed locally.
 
 ## Running the Demo
@@ -17,9 +18,9 @@ browser-based UI can call the NLP engines.
 ```
 
 Once running, open <http://localhost:8000> in a browser.  The page
-contains a form where you can enter clinical text.  Choose either the
-**MetaMapLite** or **cTAKES** engine from the *NLP Engine* menu, then
-click **Annotate**.
+contains a form where you can enter clinical text.  Choose an engine
+from the *NLP Engine* menu—**MetaMapLite**, **QuickUMLS**, or
+**cTAKES**—then click **Annotate**.
 
 ## cTAKES Requirements
 
@@ -28,3 +29,30 @@ The cTAKES option expects an existing cTAKES installation.  Set the
 directory before starting the server.  The CGI script will attempt to
 run `runClinicalPipeline.sh` from this location and return its plain
 text output.
+
+## QuickUMLS Requirements
+
+The QuickUMLS option requires the QuickUMLS Python package and a data
+directory built from your local UMLS installation.
+
+1. Install the package and its dependencies:
+
+   ```bash
+   pip install quickumls
+   ```
+
+2. Build the QuickUMLS data files using your UMLS release:
+
+   ```bash
+   python -m quickumls.install /path/to/umls /path/to/quickumls_data
+   ```
+
+3. Set the `QUICKUMLS_DIR` environment variable to the directory created
+   in the previous step before starting the server:
+
+   ```bash
+   export QUICKUMLS_DIR=/path/to/quickumls_data
+   ```
+
+When these are in place, restart `serve_metamaplite.sh` and choose the
+**QuickUMLS** engine in the demo interface.


### PR DESCRIPTION
## Summary
- mention QuickUMLS in engine list
- document how to install QuickUMLS and set `QUICKUMLS_DIR`
- update demo instructions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688151fb0e08832798fac5f4d5a1d165