### PR TITLE
Allow generate_unique_names.py to find default MRCONSO file

### DIFF
--- a/scripts/transformation/generate_unique_names.py
+++ b/scripts/transformation/generate_unique_names.py
@@ -30,7 +30,12 @@ def main() -> None:
     parser = argparse.ArgumentParser(
         description="Generate a JSON file of CUIs mapped to unique English names"
     )
-    parser.add_argument("mrconso", help="Path to MRCONSO.RRF")
+    parser.add_argument(
+        "mrconso",
+        nargs="?",
+        default="/data/MRCONSO.RRF",
+        help="Path to MRCONSO.RRF",
+    )
     parser.add_argument(
         "--output",
         default=Path("data/names/cui_unique_names.json"),


### PR DESCRIPTION
## Summary
- make MRCONSO path optional in `generate_unique_names.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68815427e55c8327b6da70f905090c16