### PR TITLE
Fix CSV field size issues

### DIFF
--- a/scripts/transformation/generate_hierarchy.py
+++ b/scripts/transformation/generate_hierarchy.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 import argparse
 import csv
 import json
+import sys
 from collections import defaultdict
 from pathlib import Path
 from typing import Dict, List, Set
@@ -10,6 +11,7 @@ from typing import Dict, List, Set
 def parse_mrconso(path: str) -> Dict[str, str]:
     """Return a mapping of CUI -> preferred English string."""
     names: Dict[str, str] = {}
+    csv.field_size_limit(sys.maxsize)
     with open(path, "r", encoding="utf-8", errors="ignore") as f:
         reader = csv.reader(f, delimiter="|")
         for row in reader:
@@ -27,6 +29,7 @@ def parse_mrconso(path: str) -> Dict[str, str]:
 def parse_mrrel(path: str) -> Dict[str, Set[str]]:
     """Return mapping of parent CUI -> set of child CUIs."""
     edges: Dict[str, Set[str]] = defaultdict(set)
+    csv.field_size_limit(sys.maxsize)
     with open(path, "r", encoding="utf-8", errors="ignore") as f:
         reader = csv.reader(f, delimiter="|")
         for row in reader:

--- a/scripts/transformation/generate_unique_names.py
+++ b/scripts/transformation/generate_unique_names.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import csv
 import json
+import sys
 from collections import defaultdict
 from pathlib import Path
 from typing import Dict, List, Set
@@ -11,6 +12,7 @@ from typing import Dict, List, Set
 def parse_mrconso(path: str) -> Dict[str, List[str]]:
     """Return mapping of CUI -> sorted list of unique English names."""
     names: Dict[str, Set[str]] = defaultdict(set)
+    csv.field_size_limit(sys.maxsize)
     with open(path, "r", encoding="utf-8", errors="ignore") as f:
         reader = csv.reader(f, delimiter="|")
         for row in reader:

--- a/scripts/transformation/generate_useful_relationships.py
+++ b/scripts/transformation/generate_useful_relationships.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 import argparse
 import csv
 import json
+import sys
 from pathlib import Path
 from typing import Dict, List, Tuple
 
@@ -10,6 +11,7 @@ def parse_mrconso(path: str) -> Tuple[Dict[str, str], Dict[str, str]]:
     """Return mappings of AUI -> label and CUI -> preferred label."""
     aui_names: Dict[str, str] = {}
     cui_pref: Dict[str, str] = {}
+    csv.field_size_limit(sys.maxsize)
     with open(path, "r", encoding="utf-8", errors="ignore") as f:
         reader = csv.reader(f, delimiter="|")
         for row in reader:
@@ -42,6 +44,7 @@ def parse_mrrel(
 ) -> List[Dict[str, str]]:
     """Return human-readable relationship records from MRREL."""
     records: List[Dict[str, str]] = []
+    csv.field_size_limit(sys.maxsize)
     with open(path, "r", encoding="utf-8", errors="ignore") as f:
         reader = csv.reader(f, delimiter="|")
         for row in reader:


### PR DESCRIPTION
## Summary
- allow large MRCONSO and MRREL fields to be read by raising the CSV field size limit

## Testing
- `python3 -m py_compile scripts/transformation/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6887e101204c8327a7c09ea7091e90a5